### PR TITLE
func_m: kernel check improvement

### DIFF
--- a/pacui
+++ b/pacui
@@ -189,16 +189,17 @@ function func_m
 		
 		local {installed_kernels,available_kernels,eol_kernels}
 		
-		filter_kernels="sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console"
+		filter_kernels="sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm"
+		filter_kernels2="virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console"
 		
 		installed_kernels=$(pacman -Qsq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "$filter_kernels" | \
+                               grep -Ev "$filter_kernels|$filter_kernels2" | \
                                sort)
 		
 		available_kernels=$(pacman -Ssq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "$filter_kernels" | \
+                               grep -Ev "$filter_kernels|$filter_kernels2" | \
                                sort)
 		
 		if [[ -n "$available_kernels" ]]
@@ -206,8 +207,8 @@ function func_m
 			eol_kernels=$(comm -13 <(echo "$available_kernels") <(echo "$installed_kernels"))
 
 			if [[ -n "$eol_kernels" ]]
-			then  
-			      echo " "
+			then  	
+				echo " "
 				echo -e "\e[1mThe following Linux kernel(s) are not available in your repositories \e[0m"
 				echo -e "\e[1mIf one or more of the following kernel(s) taken from AUR, you may safely ignore it \e[0m"
 				echo -e "\e[1mOther than that, the following kernel(s) may have reached their end-of-live status \e[0m"

--- a/pacui
+++ b/pacui
@@ -189,17 +189,14 @@ function func_m
 		
 		local {installed_kernels,available_kernels,eol_kernels}
 		
-		filter_kernels="sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm"
-		filter_kernels2="virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console"
-		
 		installed_kernels=$(pacman -Qsq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "$filter_kernels|$filter_kernels2" | \
+                               grep -E "^linux[0-9]*$|^linux$|hardened$|lts$|zen$|rt-lts-manjaro$|rt-manjaro$" | \
                                sort)
 		
 		available_kernels=$(pacman -Ssq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "$filter_kernels|$filter_kernels2" | \
+                               grep -E "^linux[0-9]*$|^linux$|hardened$|lts$|zen$|rt-lts-manjaro$|rt-manjaro$" | \
                                sort)
 		
 		if [[ -n "$available_kernels" ]]
@@ -210,7 +207,7 @@ function func_m
 			then  	
 				echo " "
 				echo -e "\e[1mThe following Linux kernel(s) are not available in your repositories \e[0m"
-				echo -e "\e[1mIf one or more of the following kernel(s) taken from AUR, you may safely ignore it \e[0m"
+				echo -e "\e[1mIf one or more of the following kernel(s) taken from AUR (or custom repo), you may safely ignore it \e[0m"
 				echo -e "\e[1mOther than that, the following kernel(s) may have reached their end-of-live status \e[0m"
 				echo -e "\e[1mDo not expect any security or stability fixes for the following kernel(s) anymore \e[0m"
 				echo -e "\e[1mKernel modules are likely to break. Please remove them if there are any: \e[0m"

--- a/pacui
+++ b/pacui
@@ -183,32 +183,39 @@ function func_m
 			fi
 		fi
 		
+		## KERNEL CHECK
 		
-		if [[ -e /usr/bin/mhwd ]]	# checks, whether file "mhwd" exists, i.e. "mhwd" is installed. this is only true for manjaro, but not for arch linux.
+		echo "checking installed kernels ..."
+		
+		local {installed_kernels,available_kernels,eol_kernels}
+		
+		installed_kernels=$(pacman -Qsq "^linux" | \
+                               grep "linux" | \
+                               grep -Ev "sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console" | \
+                               sort)
+		
+		available_kernels=$(pacman -Ssq "^linux" | \
+                               grep "linux" | \
+                               grep -Ev "sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console" | \
+                               sort)
+		
+		if [[ -n "$available_kernels" ]]
 		then
-			echo "checking installed kernels ..."
-			# check, if any installed kernel is EOL:
-			# 0. delete old temporary file to avoid strange errors. ignore all output of "rm" command (such as output, messages, or errors).
-			rm /tmp/.installed_kernels /tmp/.available_kernels /tmp/.eol_kernels &>/dev/null
-			# 1. create lists of installed and available kernels (and ignore all errors).
-			mhwd-kernel -li 2>/dev/null | awk '/ linux/ {print $2}' | sort > /tmp/.installed_kernels
-			mhwd-kernel -l 2>/dev/null | awk '/linux/ {print $2}' | sort > /tmp/.available_kernels
-			# 2. Check if installed kernels are eol:
-			if ! [[ -z $(cat /tmp/.available_kernels) ]]   # make sure that file is not empty. it is better not to display anything than something wrong.
-			then
-				# write all kernels, which are installed, but not available anymore, to /tmp/.eol_kernels
-				comm -13 /tmp/.available_kernels /tmp/.installed_kernels  > /tmp/.eol_kernels
+			eol_kernels=$(comm -13 <(echo "$available_kernels") <(echo "$installed_kernels"))
 
-				if ! [[ -z $(cat /tmp/.eol_kernels) ]]   # make sure that file is not empty
-				then
-					echo -e "\e[1mThe following Linux kernels have reached their end-of-live status. \e[0m"
-					echo -e "\e[1mDo not expect any security or stability fixes for those kernels anymore. \e[0m"
-					echo -e "\e[1mKernel modules are likely to break. Please remove these Linux kernels: \e[0m"
-					cat /tmp/.eol_kernels
-				fi
+			if [[ -n "$eol_kernels" ]]
+			then  
+			      echo " "
+				echo -e "\e[1mThe following Linux kernel(s) are not available in your repositories \e[0m"
+				echo -e "\e[1mIf one or more of the following kernel(s) taken from AUR, you may safely ignore it \e[0m"
+				echo -e "\e[1mOther than that, the following kernel(s) may have reached their end-of-live status \e[0m"
+				echo -e "\e[1mDo not expect any security or stability fixes for the following kernel(s) anymore \e[0m"
+				echo -e "\e[1mKernel modules are likely to break. Please remove them if there are any: \e[0m"
+				echo "$eol_kernels"
 			fi
 		fi
-		echo ""
+	      
+	      echo ""
 }
 
 

--- a/pacui
+++ b/pacui
@@ -189,14 +189,16 @@ function func_m
 		
 		local {installed_kernels,available_kernels,eol_kernels}
 		
+		filter_kernels="sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console"
+		
 		installed_kernels=$(pacman -Qsq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console" | \
+                               grep -Ev "$filter_kernels" | \
                                sort)
 		
 		available_kernels=$(pacman -Ssq "^linux" | \
                                grep "linux" | \
-                               grep -Ev "sys|util|api|docs|firmware|arch|nvidia|manpages|headers|tools|atm|virtual|rt3|r8|vhba|catalyst|ndiswrapper|bbswitch|broadcom|acpi|spl|zfs|logo|tv|sampler|console" | \
+                               grep -Ev "$filter_kernels" | \
                                sort)
 		
 		if [[ -n "$available_kernels" ]]


### PR DESCRIPTION
This commit changes kernel check in func_m :
	- To use variables completely and locally ( Thus removing the necessity of temporary files)
	- Use pacman for search kernel in both local and remote (removing mhwd completely)
	- Improve warning messages

This commit will hopefully fixes : https://forum.manjaro.org/t/using-pacui-produces-output-related-to-end-of-life-kernels/32550/

Signed-off-by: Rafli Akmal <rafliakmaltejakusuma@gmail.com>