### PR TITLE
kernel-check/available_kernels: use pacman search only

### DIFF
--- a/pacui
+++ b/pacui
@@ -186,11 +186,11 @@ function func_m
 		
 		echo "checking installed kernels ..."
 		local {installed_kernels,available_kernels,eol_kernels}		# declare local variables
-		installed_kernels=$( for p in `command ls -1 /boot | grep -E '^vmlinuz'`; do pacman -Qqo /boot/$p | sort; done )					# filter installed kernels from boot sector and determine, which package owns that file. this yields the package name of all installed kernels (including kernels from the AUR).
-		available_kernels=$( pacman -Ssq "^linux" | grep "linux" | grep -E "^linux[0-9]*$|hardened$|lts$|zen$|rt-lts-manjaro$|rt-manjaro$" | sort )		# filter package names of kernels available in the repos for both manjaro (kernel names always like "linux414" (and rt-versions!!!)) and arch linux (these are the only kernel names (which never change): "linux", "linux-lts", "linux-hardened", "linux-zen").
+		installed_kernels=$( for p in `command ls -1 /boot | grep -E '^vmlinuz'`; do pacman -Qqo /boot/$p ; done | sort -u )					# filter installed kernels from boot sector and determine, which package owns that file. this yields the package name of all installed kernels (including kernels from the AUR).
+		available_kernels=$( for p in `echo "$installed_kernels"`; do pacman -Ssq "^$p$" ; done | sort -u )		# Check if installed kernels available in repositories and forward it to available_kernels variable.
 		if [[ -n "$available_kernels" ]]
 		then
-			eol_kernels=$(comm -13 <(echo "$available_kernels") <(echo "$installed_kernels"))		# filter kernels to $eol_kernels variable, which are installed but no longer available.
+			eol_kernels=$(comm -13 <(echo "$available_kernels") <(echo "$installed_kernels") | sort -u )		# filter kernels to $eol_kernels variable, which are installed but no longer available.
 			# print warning message, if end-of-life kernel(s) are found:
 			if [[ -n "$eol_kernels" ]]
 			then  	
@@ -202,7 +202,7 @@ function func_m
 				echo "$eol_kernels"
 			fi
 		fi
-                echo ""
+            echo ""
 }
 
 

--- a/pacui
+++ b/pacui
@@ -188,19 +188,16 @@ function func_m
 		local {installed_kernels,available_kernels,eol_kernels}		# declare local variables
 		installed_kernels=$( for p in `command ls -1 /boot | grep -E '^vmlinuz'`; do pacman -Qqo /boot/$p ; done | sort -u )					# filter installed kernels from boot sector and determine, which package owns that file. this yields the package name of all installed kernels (including kernels from the AUR).
 		available_kernels=$( for p in `echo "$installed_kernels"`; do pacman -Ssq "^$p$" ; done | sort -u )		# Check if installed kernels available in repositories and forward it to available_kernels variable.
-		if [[ -n "$available_kernels" ]]
-		then
-			eol_kernels=$(comm -13 <(echo "$available_kernels") <(echo "$installed_kernels") | sort -u )		# filter kernels to $eol_kernels variable, which are installed but no longer available.
-			# print warning message, if end-of-life kernel(s) are found:
-			if [[ -n "$eol_kernels" ]]
-			then  	
-				echo " "
-				echo -e "\e[1mThe following Linux kernel(s) are no longer available in your repositories. \e[0m"
-				echo -e "\e[1mDo not expect any security or stability fixes for the(se) kernel(s) anymore. \e[0m"
-				echo -e "\e[1mKernel modules are likely to break. It is recommended to remove the kernel(s).\e[0m"
-				echo -e "\e[1mIf one or more of the following kernel(s) are taken from AUR, you may safely ignore this warning. \e[0m"
-				echo "$eol_kernels"
-			fi
+		eol_kernels=$( comm -13 <(echo "$available_kernels") <(echo "$installed_kernels") )		# filter kernels to $eol_kernels variable, which are installed but no longer available.
+		# print warning message, if end-of-life kernel(s) are found:
+		if [[ -n "$eol_kernels" ]]
+		then  	
+			echo " "
+			echo -e "\e[1mThe following Linux kernel(s) are no longer available in your repositories. \e[0m"
+			echo -e "\e[1mDo not expect any security or stability fixes for the(se) kernel(s) anymore. \e[0m"
+			echo -e "\e[1mKernel modules are likely to break. It is recommended to remove the kernel(s).\e[0m"
+			echo -e "\e[1mIf one or more of the following kernel(s) are taken from AUR, you may safely ignore this warning. \e[0m"
+			echo "$eol_kernels"
 		fi
             echo ""
 }


### PR DESCRIPTION
This make available_kernels to check if installed_kernels are available in repositories and forward it to available_kernels itself
Thus removing grep command completely

Signed-off-by: Rafli Akmal <rafliakmaltejakusuma@gmail.com>

---

PS : Sorry If I opened another pull request :(((