### PR TITLE
Merge update and devel update commands

### DIFF
--- a/pacui
+++ b/pacui
@@ -1697,7 +1697,7 @@ function func_ua
 {
         if [[ "$AUR_Helper" == "yay" ]]
         then
-            yay "$argument_flag"-Syu && yay -Syu --devel --needed --noconfirm
+            yay "$argument_flag"-Syu --devel --needed
 
         elif [[ "$AUR_Helper" == "pikaur" ]]
         then
@@ -1705,7 +1705,7 @@ function func_ua
 
         elif [[ "$AUR_Helper" == "aurman" ]]
         then
-            aurman "$argument_flag"-Syu && aurman -Syu --devel --needed --noconfirm
+            aurman "$argument_flag"-Syu --devel --needed
 
         elif [[ "$AUR_Helper" == "pakku" ]]
         then
@@ -1713,7 +1713,7 @@ function func_ua
 
         elif [[ "$AUR_Helper" == "trizen" ]]
         then
-            trizen "$argument_flag"-Syu && trizen -Syu --devel --needed --noconfirm
+            trizen "$argument_flag"-Syu --devel --needed
 
         elif [[ "$AUR_Helper" == "pacaur" ]]
         then


### PR DESCRIPTION
Based on recent events and discussions, I think it's best to not use --noconfirm. Although this isn't just about that, personally I have a huge dislike of --noconfirm usage.

Also I am very confused as to why you split the commands to `update && devel update`. This has no benefit, for yay at least, but I would assume most AUR helpers are similar.

Also I don't understand why you also pass --needed to every command. I know that pacaur uses `--needed` to filter out the 'needed' updates for `--devel`. But as far as I know this does nothing for other helpers. I've left it in though, has it doesn't really have any negatives.