### PR TITLE
Add bauerbill support

### DIFF
--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -1,10 +1,11 @@
 # Maintainer: Stefano Capitani <stefanoatmanjarodotorg>
 # Maintainer: excalibur1234 @forum.manjaro.org
+# Contributor: timescam <rex.ky.ng at gmail dot com>
 
 _pkgname=pacui
 pkgname=$_pkgname-git
 pkgver=r1024.90efdc4
-pkgrel=1
+pkgrel=2
 pkgdesc="Bash script providing advanced Pacman and Yay/Pikaur/Aurman/Pakku/Trizen/Pacaur functionality in a simple UI"
 arch=(any)
 url="https://github.com/excalibur1234/$_pkgname"
@@ -13,7 +14,8 @@ depends=('pacman-contrib' 'expac' 'sudo' 'fzf')
 makedepends=('git')
 provides=("$_pkgname")
 conflicts=("$_pkgname")
-optdepends=('yay: One AUR helper is needed for AUR support'
+optdepends=('bauerbill: One AUR helper is needed for AUR support'
+            'yay: One AUR helper is needed for AUR support'
             'pikaur: One AUR helper is needed for AUR support'
             'aurman: One AUR helper is needed for AUR support'
             'pakku: One AUR helper is needed for AUR support'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # PacUI
 
-PacUI provides useful and advanced Pacman and Yay/Pikaur/Aurman/Pakku/Trizen/Pacaur/Pamac-cli commands in a convenient and easy to use text interface.
+PacUI provides useful and advanced Pacman and bauerbill/Yay/Pikaur/Aurman/Pakku/Trizen/Pacaur/Pamac-cli commands in a convenient and easy to use text interface.
 
-PacUI is aimed at experienced/intermediate/advanced users of Arch Linux (and Arch-based distributions, including Manjaro), who have at least basic knowledge of their Linux system, Pacman and [Yay](https://github.com/Jguer/yay)/[Pikaur](https://github.com/actionless/pikaur)/[Aurman](https://github.com/polygamma/aurman)/[Pakku](https://github.com/kitsunyan/pakku)/[Trizen](https://github.com/trizen/trizen)/[Pacaur](https://github.com/rmarquis/pacaur)/[Pamac-cli](https://aur.archlinux.org/packages/pamac-cli/). Absolute beginners are probably overwhelmed by the choices PacUI offers.
+PacUI is aimed at experienced/intermediate/advanced users of Arch Linux (and Arch-based distributions, including Manjaro), who have at least basic knowledge of their Linux system, Pacman and [bauerbill](https://xyne.archlinux.ca/projects/bauerbill/)/[Yay](https://github.com/Jguer/yay)/[Pikaur](https://github.com/actionless/pikaur)/[Aurman](https://github.com/polygamma/aurman)/[Pakku](https://github.com/kitsunyan/pakku)/[Trizen](https://github.com/trizen/trizen)/[Pacaur](https://github.com/rmarquis/pacaur)/[Pamac-cli](https://aur.archlinux.org/packages/pamac-cli/). Absolute beginners are probably overwhelmed by the choices PacUI offers.
 
 This fork of an [older version of pacli](https://github.com/Manjaro-Pek/pacli/tree/f98e9226eb75ea00217481f436399328fe73d3ae) called PacUI follows the KISS principle: The whole script is contained within one file, which consists of easy to read bash code with many helpful comments. PacUI offers many more features over pacli in order to enhance comfort and speed of CLI based package management.
 
@@ -127,7 +127,7 @@ Examples:
 
 
 ### Multiple installed AUR helpers
-Please note that PacUI optionally requires at least one of these AUR helpers to enable use of the AUR.: [Yay](https://github.com/Jguer/yay), [Pikaur](https://github.com/actionless/pikaur), [Aurman](https://github.com/polygamma/aurman), [Pakku](https://github.com/kitsunyan/pakku), [Trizen](https://github.com/trizen/trizen), [Pacaur](https://github.com/rmarquis/pacaur), or [Pamac-cli](https://aur.archlinux.org/packages/pamac-cli/).
+Please note that PacUI optionally requires at least one of these AUR helpers to enable use of the AUR.: [bauerbill](https://xyne.archlinux.ca/projects/bauerbill/), [Yay](https://github.com/Jguer/yay), [Pikaur](https://github.com/actionless/pikaur), [Aurman](https://github.com/polygamma/aurman), [Pakku](https://github.com/kitsunyan/pakku), [Trizen](https://github.com/trizen/trizen), [Pacaur](https://github.com/rmarquis/pacaur), or [Pamac-cli](https://aur.archlinux.org/packages/pamac-cli/).
 
 If more than one AUR helper is installed, they are automatically used in the same order as listed above (i.e. Aurman is used with priority while Pacaur is only used as a last resort). A specific AUR helper can be set with the `PACUI_AUR_HELPER` environment variable.
 

--- a/pacui
+++ b/pacui
@@ -2009,7 +2009,7 @@ function func_ua
 {
         if [[ "$AUR_Helper" == "bauerbill" ]]
         then
-            bb-wrapper --aur "$argument_flag"-Syu
+            bb-wrapper --aur "$argument_flag" --build-vcs -Syu
 
         elif [[ "$AUR_Helper" == "yay" ]]
         then

--- a/pacui
+++ b/pacui
@@ -50,7 +50,11 @@ AUR_Helper="$PACUI_AUR_HELPER"                                                  
 if [[ -z "$AUR_Helper" ]]                                                           # check, if AUR_Helper variable is empty. more precise: check, if output of "$AUR_Helper" is zero
 then
 
-    if [[ -f /usr/bin/yay ]]                                                        # check, if /usr/bin/yay file exists (i.e. yay is installed)
+    if [[ -f /usr/bin/bb-wrapper ]]                                                   # check, if /usr/bin/bb-wrapper file exists (i.e. bauerbill is installed)
+    then
+        AUR_Helper="bauerbill"
+
+    elif [[ -f /usr/bin/yay ]]
     then
         AUR_Helper="yay"
 
@@ -108,7 +112,18 @@ function func_u
         local install_successful
         install_successful=false
 
-        if [[ "$AUR_Helper" == "yay" ]]                                             # check, if $AUR_Helper variable is set to "yay". ATTENTION: sometimes, this requires   [[ "$AUR_Helper" == "yay" ]]   and sometimes   test '$AUR_Helper' = "yay"  . i do not know why this is the case.
+        if [[ "$AUR_Helper" == "bauerbill" ]]                                         # check, if $AUR_Helper variable is set to "bauerbill". ATTENTION: sometimes, this requires   [[ "$AUR_Helper" == "bauerbill" ]]   and sometimes   test '$AUR_Helper' = "bauerbill"  . i do not know why this is the case.
+        then
+
+            # execute "bb-wrapper --aur -Syu" command:
+            if ( bb-wrapper --aur "$argument_flag"-Syu )                            # execute command "bb-wrapper --aur -Syu". if this command fails "false" is returned and the result is: "if ( false )"
+            then
+                # only set $install_successful=true, if the command "bb-wrapper -Syu" was executed without errors
+                install_successful=true
+            else
+                install_successful=false
+            fi
+        elif [[ "$AUR_Helper" == "yay" ]]                                             # check, if $AUR_Helper variable is set to "yay". ATTENTION: sometimes, this requires   [[ "$AUR_Helper" == "yay" ]]   and sometimes   test '$AUR_Helper' = "yay"  . i do not know why this is the case.
         then
 
             # execute "yay -Syu" command:
@@ -623,7 +638,11 @@ function func_i
                             then
                                 echo -e "\e[1mAUR package info: \e[0m"
 
-                                if test '$AUR_Helper' = "yay"
+                                if test '$AUR_Helper' = "bauerbill"
+                                then
+                                    bauerbill -Si {1}
+                                
+                                elif test '$AUR_Helper' = "yay"
                                 then
                                     yay -Si {1} | grep -v "::"                      # grep command removes all errors displayed by yay
 
@@ -680,7 +699,11 @@ function func_i
         if [[ -n "$pkg" ]]
         then
 
-            if [[ "$AUR_Helper" == "yay" ]]
+            if [[ "$AUR_Helper" == "bauerbill" ]]
+            then
+                bb-wrapper --aur "$argument_flag"-S $pkg                            # ATTENTION: (i do not know why but) using quotes (" symbols) around $pkg variable breaks AUR helper and pacman
+
+            elif [[ "$AUR_Helper" == "yay" ]]
             then
                 yay "$argument_flag"-S $pkg                                         # ATTENTION: (i do not know why but) using quotes (" symbols) around $pkg variable breaks AUR helper and pacman
 
@@ -1984,7 +2007,11 @@ function func_ls
 # this function provides core functionality of "Force Update AUR". the help page provides additional explanations.
 function func_ua
 {
-        if [[ "$AUR_Helper" == "yay" ]]
+        if [[ "$AUR_Helper" == "bauerbill" ]]
+        then
+            bb-wrapper --aur "$argument_flag"-Syu
+
+        elif [[ "$AUR_Helper" == "yay" ]]
         then
             yay "$argument_flag"-Syu --devel --needed
 
@@ -2014,6 +2041,7 @@ function func_ua
 
         else
             echo -e " \e[41m No AUR helper has been found. Please install at least one supported AUR helper manually: \e[0m"
+            echo -e " \e[1m  bauerbill \e[0m"
             echo -e " \e[1m  yay \e[0m"
             echo -e " \e[1m  pikaur \e[0m"
             echo -e " \e[1m  aurman \e[0m"
@@ -2054,7 +2082,11 @@ function func_la
             then
                 echo -e "\e[1mAUR package info: \e[0m"
 
-                if test '$AUR_Helper' = "yay"
+                if test '$AUR_Helper' = "bauerbill"
+                then
+                    bauerbill -Si {1}
+
+                elif test '$AUR_Helper' = "yay"
                 then
                     yay -Si {1} | grep -v "::"                                      # grep command removes all errors displayed by yay
 
@@ -2157,7 +2189,11 @@ function func_a
         then
             # do this if variable "$argument_input" is not empty:
 
-            if [[ "$AUR_Helper" == "yay" ]]
+            if [[ "$AUR_Helper" == "bauerbill" ]]
+            then
+                bauerbill -Ss "$argument_input"
+
+            elif [[ "$AUR_Helper" == "yay" ]]
             then
                 yay "$argument_input"
 
@@ -2187,6 +2223,7 @@ function func_a
 
             else
                 echo -e " \e[41m No AUR helper has been found. Please install at least one supported AUR helper manually: \e[0m"
+                echo -e " \e[1m  bauerbill \e[0m"
                 echo -e " \e[1m  yay \e[0m"
                 echo -e " \e[1m  pikaur \e[0m"
                 echo -e " \e[1m  aurman \e[0m"
@@ -2203,7 +2240,11 @@ function func_a
             echo -e " \e[41m Enter (parts of) name and/or description of package to be searched. Then press ENTER. \e[0m"
             read -r pkg
 
-            if [[ "$AUR_Helper" == "yay" ]]
+            if [[ "$AUR_Helper" == "bauerbill" ]]
+            then
+                bauerbill -Ss "$pkg"
+                
+            elif [[ "$AUR_Helper" == "yay" ]]
             then
                 yay "$pkg"
 
@@ -2233,6 +2274,7 @@ function func_a
 
             else
                 echo -e " \e[41m No AUR helper has been found. Please install at least one supported AUR helper manually: \e[0m"
+                echo -e " \e[1m  bauerbill \e[0m"
                 echo -e " \e[1m  yay \e[0m"
                 echo -e " \e[1m  pikaur \e[0m"
                 echo -e " \e[1m  aurman \e[0m"


### PR DESCRIPTION
# Changes

Added [**bauerbill**](https://xyne.archlinux.ca/projects/bauerbill/) and its built-in wrapper (bb-wrapper) as aur support. Also updated README.md and PKGBUILD-git of the new optional dependencies.

## why bauerbill

[**powerpill**](https://xyne.archlinux.ca/projects/powerpill/) is a Pacman wrapper that uses parallel and segmented downloading through Aria2 and Reflector to try to speed up downloads for Pacman, with **bauerbill** it also supports AUR and ABS.

## todo

update both PKGBUILD and PKGBULD_AUR after the new release.